### PR TITLE
Add meta data option to REST API

### DIFF
--- a/src/content/rest-example-code.js
+++ b/src/content/rest-example-code.js
@@ -14,4 +14,4 @@ Promise.all([
   restRequest(`/blog`),
   restRequest(`/posts?fields=title,slug,publishDate&limit=3`)
 ])
-.then(([blog, posts]) => console.log({ blog, posts }))
+.then(([blog, { items: posts }]) => console.log({ blog, posts }))

--- a/src/rest/index.js
+++ b/src/rest/index.js
@@ -98,7 +98,7 @@ function getCollectionItemMeta ({ item, Model, req }) {
   ].filter(Boolean)
   const url = `${getBaseUrl(req)}/api/${restVersion}${req.route.path}/${item.slug}?${queryParams.join('&')}`
   return {
-    kind: Model.name,
+    type: Model.name,
     self: item.slug ? url : undefined
   }
 }
@@ -122,7 +122,7 @@ function routeCollection (Model) {
     const { fields, language, limit, offset } = req.query
     const useMeta = req.query.meta
     const meta = useMeta ? {
-      kind: `${Model.name}Collection`,
+      type: `${Model.name}Collection`,
       self: `${getBaseUrl(req)}${req.originalUrl}`
     } : undefined
     const items = (await Model.find({ language, limit, offset }))
@@ -144,7 +144,7 @@ function routeItem (Model) {
       return next(new NotFoundError(`No ${Model.name} found with slug '${slug}'`))
     }
     const meta = useMeta ? {
-      kind: Model.name,
+      type: Model.name,
       self: `${getBaseUrl(req)}${req.originalUrl}`
     } : undefined
     if (Array.isArray(fields)) {
@@ -172,7 +172,7 @@ function routePage (Model) {
     const { language, fields = defaultFields } = req.query
     const useMeta = req.query.meta
     const meta = useMeta ? {
-      kind: Model.name,
+      type: Model.name,
       self: `${getBaseUrl(req)}${req.originalUrl}`
     } : undefined
     const page = await Model.findOne({ language })

--- a/src/rest/index.test.js
+++ b/src/rest/index.test.js
@@ -3,6 +3,7 @@ const { test } = require('ava')
 const express = require('express')
 const restRouter = require('./')
 const request = require('supertest')
+const { URL } = require('url')
 
 function makeApp () {
   const app = express()
@@ -13,6 +14,15 @@ function makeApp () {
 function getRequest(url) {
   const app = makeApp()
   return request(app).get(url)
+}
+
+function isValidUrl(url) {
+  try {
+    new URL(url)
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 test('Invalid endpoint returns ROUTE_NOT_FOUND error', async t => {
@@ -54,13 +64,30 @@ test('Invalid fields parameter returns INVALID_PARAMETER error', async t => {
 test('Returns list of projects', async t => {
   const res = await getRequest('/projects?language=en')
   t.is(res.status, 200)
-  t.true(Array.isArray(res.body))
+  t.true(Array.isArray(res.body.items))
   t.falsy(res.body.error)
+})
+
+test('Includes meta properties if `meta` parameter is true', async t => {
+  const res = await getRequest('/projects?language=en&meta=true')
+  const { items, meta } = res.body
+  t.is(res.status, 200)
+  t.is(meta.kind, 'ProjectCollection')
+  t.true(isValidUrl(meta.self))
+  t.is(items[0].meta.kind, 'Project')
+  t.true(isValidUrl(items[0].meta.self))
+})
+
+test('Includes no meta properties if `meta` parameter is falsy', async t => {
+  const res = await getRequest('/projects?language=en')
+  t.is(res.status, 200)
+  t.is(res.body.meta, undefined)
+  t.is(res.body.items[0].meta, undefined)
 })
 
 test('Returns a single project', async t => {
   const resAll = await getRequest('/projects?language=en&limit=1&fields=slug,title')
-  const items = resAll.body
+  const { items } = resAll.body
   const resOne = await getRequest(`/projects/${items[0].slug}?language=en&fields=slug,title`)
   const item = resOne.body
   t.is(resOne.status, 200)

--- a/src/rest/index.test.js
+++ b/src/rest/index.test.js
@@ -90,9 +90,9 @@ test('Includes meta properties if `meta` parameter is true', async t => {
   const res = await getRequest('/projects?language=en&meta=true')
   const { items, meta } = res.body
   t.is(res.status, 200)
-  t.is(meta.kind, 'ProjectCollection')
+  t.is(meta.type, 'ProjectCollection')
   t.true(isValidUrl(meta.self))
-  t.is(items[0].meta.kind, 'Project')
+  t.is(items[0].meta.type, 'Project')
   t.true(isValidUrl(items[0].meta.self))
 })
 

--- a/src/rest/schema/index.js
+++ b/src/rest/schema/index.js
@@ -38,6 +38,11 @@ const parameters = {
     in: 'query',
     type: 'number',
   },
+  meta: {
+    name: 'meta',
+    in: 'query',
+    type: 'boolean',
+  },
   slug: {
     name: 'slug',
     in: 'path',
@@ -58,6 +63,9 @@ module.exports = {
   paths: {
     '/blog': {
       'get': {
+        parameters: [
+          parameters.meta,
+        ],
         responses: {
           '200': {
             description: 'Blog overview',
@@ -70,6 +78,7 @@ module.exports = {
       'get': {
         parameters: [
           parameters.language,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -83,6 +92,7 @@ module.exports = {
       'get': {
         parameters: [
           parameters.language,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -98,6 +108,7 @@ module.exports = {
           parameters.language,
           parameters.fields(Event),
           parameters.limit,
+          parameters.meta,
           parameters.offset,
         ],
         responses: {
@@ -115,6 +126,7 @@ module.exports = {
       'get': {
         parameters: [
           parameters.language,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -129,6 +141,7 @@ module.exports = {
         parameters: [
           parameters.language,
           parameters.fields(Job),
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -147,6 +160,7 @@ module.exports = {
           parameters.slug,
           parameters.language,
           parameters.fields(Job),
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -162,6 +176,7 @@ module.exports = {
           parameters.fields(Post),
           parameters.limit,
           parameters.offset,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -179,6 +194,7 @@ module.exports = {
         parameters: [
           parameters.slug,
           parameters.fields(Post),
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -195,6 +211,7 @@ module.exports = {
           parameters.fields(Project),
           parameters.limit,
           parameters.offset,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -213,6 +230,7 @@ module.exports = {
           parameters.slug,
           parameters.language,
           parameters.fields(Project),
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -226,6 +244,7 @@ module.exports = {
       'get': {
         parameters: [
           parameters.language,
+          parameters.meta,
         ],
         responses: {
           '200': {
@@ -239,6 +258,7 @@ module.exports = {
       'get': {
         parameters: [
           parameters.language,
+          parameters.meta,
         ],
         responses: {
           '200': {


### PR DESCRIPTION
Based on https://pages.apigee.com/rs/351-WXY-166/images/Web-design-the-missing-link-ebook-2016-11.pdf

BREAKING CHANGE: collection routes now nest the items into the items field:
`{  items: [ { ... }, { ... } ] }` instead of `[ { ... }, { ... } ]` so that the response can contain meta: `{ meta: { ... }, items: [ ... ] }`

Resolves #13