### PR TITLE
Fix doc url for routes with /:slug

### DIFF
--- a/src/rest/index.js
+++ b/src/rest/index.js
@@ -81,7 +81,7 @@ function getBaseUrl (req) {
 function getDocsUrl (req) {
   const baseUrl = getBaseUrl(req)
   const method = req.method.toLowerCase()
-  const path = req.route.path.replace('/','_')
+  const path = req.route.path.replace(/\//g,'_').replace(':slug', '_slug_')
   return `${baseUrl}/api/${restVersion}#/default/${method}${path}`
 }
 


### PR DESCRIPTION
Resolves #28: now does have correct doc url: https://voorhoede-colibri-api-nuuhvldara.now.sh/api/v1/posts/every-project-a-progressive-web-app?fields=titles