### PR TITLE
Use NOW_URL as BASE_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "now -e NODE_ENV=production && now alias",
     "dev": "nodemon --watch src src/index.js",
     "start": "cross-env NODE_ENV=production node src/index.js",
-    "now-start": "BASE_URL=https://voorhoede-colibri-api.now.sh npm start",
+    "now-start": "BASE_URL=$NOW_URL npm start",
     "test": "ava src/**/*.test.js",
     "watch": "npm run watch:test",
     "watch:test": "npm test -- --watch"


### PR DESCRIPTION
so app uses the url of the deployment itself rather than the alias.

See [NOW_URL](https://zeit.co/docs/features/env-and-secrets#default-variables)